### PR TITLE
Please incorporate grouping-support

### DIFF
--- a/ux/grid/gridPrinterCss/print.css
+++ b/ux/grid/gridPrinterCss/print.css
@@ -95,3 +95,8 @@ html.x-ux-grid-printer, .x-ux-grid-printer img,.x-ux-grid-printer body {
         display: none;
     }
 }
+.group-header {
+    border-bottom : 2px solid black;
+    font-size     : 14px;
+}
+


### PR DESCRIPTION
Only very small changes were applied to the existing code.
Great care has been taken to integrate as seamlessly, as possible.
Changes are mainly added in "getFeature" and "getBody".

getBody returns the whole structure for grouping and a single row
for the "classic" case without grouping, which can be a little
confusing.

The optics of the group-header is determined by an entry added
to print.css (.group-header) and by XTemplate configuration:

``` javascript
              headerPrefix          : this.groupHeaderPrefix,
              headerPostfixSingular : this.groupHeaderPostfixSingular,
              headerPostfixPlural   : this.groupHeaderPostfixPlural,
              postfixWithParens     : true,
```

I tested with grids with and without grouping and they all looked fine.

One little drawback: by using Array.filter the gridprinter-plugin now requires rather modern browsers (IE supports that function from version 9 on). To solve this, I added the mozilla-implementation of Array.filter (if not present already) in a file that gets loaded in all my projects:

``` javascript
if (!Array.prototype.filter)
{
  Array.prototype.filter = function(fun /*, thisp */)
  {
    // the code here ...
  }
}
```

I would be happy if you would agree to incorporate these changes into your code.
Please feel free to change the code as you deem necessary or contact me if you have any questions/suggestions.

Thanks,
orrence.
