### PR TITLE
Bugfix: print data of grids with grouping only once

### DIFF
--- a/ux/grid/Printer.js
+++ b/ux/grid/Printer.js
@@ -212,7 +212,7 @@ Ext.define("Ext.ux.grid.Printer", {
                               body,
                            '</tr>',
                            pluginsBodyMarkup.join(''),
-                           '{% if (this.isGrouped && xindex > 1) break; %}',
+                           '{% if (this.isGrouped && xindex > 0) break; %}',
                         '</tpl>',
                     '</table>',
                   '</body>',


### PR DESCRIPTION
Hi!
Changed break condition from ">1" to ">0" in Printer.js,
so now data for grids with grouping correctly gets printed only once.
Cheers,
orrence.
