### PR TITLE
Added checkcolumn support (compatible since Ext 4.0.x)

### DIFF
--- a/ux/grid/Printer.js
+++ b/ux/grid/Printer.js
@@ -306,7 +306,7 @@ Ext.define("Ext.ux.grid.Printer", {
                     		value = column.tpl ? column.tpl.apply(rcd.data) : value;
                     	}
                     	else if (column.renderer) {
-                            if (column instanceof Ext.tree.Column) {
+                            if (column instanceof Ext.tree.Column || column.xtype == 'checkcolumn') { // to keep compatibility w/ Ext. 4.0 (since checkcolumn was introduced at 4.2.x)
                                 value = column.renderer.call(column, value, meta, rcd, -1, col - 1, this.grid.store, this.grid.view);
                             } else {
                                 value = column.renderer.call(this.grid, value, meta, rcd, -1, col - 1, this.grid.store, this.grid.view);


### PR DESCRIPTION
Hello, I'm currently working w/ Ext 6.2.1 and we use gridprinter since Ext 4.0.
I need to use Printer in grids configured with Check column (Ext.grid.column.Check).

Line 302:
Since the Check renderer method call expects the column itself as scope (not the grid), I needed to add this check to avoid warning and malfunction of Printer class.